### PR TITLE
Parameters SSL_CA_File, SSL_Client_CA_File, SSL_Verify_Mode

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+0.0305  2016-12-16      Thomas Stinner <me@stinnux.de>
+
+* Allow setting of SSL CA and SSL Verification Mode
+
 0.0304  2016-03-28      Piotr Roszatycki <dexter@cpan.org>
 
 * Use address 127.0.0.1 rather than localhost for testing.

--- a/lib/Plack/Handler/Thrall.pm
+++ b/lib/Plack/Handler/Thrall.pm
@@ -3,7 +3,7 @@ package Plack::Handler::Thrall;
 use strict;
 use warnings;
 
-our $VERSION = '0.0304';
+our $VERSION = '0.0305';
 
 use base qw(Thrall::Server);
 

--- a/lib/Thrall.pm
+++ b/lib/Thrall.pm
@@ -36,7 +36,7 @@ use 5.008_001;
 use strict;
 use warnings;
 
-our $VERSION = '0.0304';
+our $VERSION = '0.0305';
 
 1;
 

--- a/lib/Thrall/Server.pm
+++ b/lib/Thrall/Server.pm
@@ -3,7 +3,7 @@ package Thrall::Server;
 use strict;
 use warnings;
 
-our $VERSION = '0.0304';
+our $VERSION = '0.0305';
 
 use Config;
 
@@ -58,6 +58,9 @@ sub new {
         ipv6                 => $args{ipv6},
         ssl_key_file         => $args{ssl_key_file},
         ssl_cert_file        => $args{ssl_cert_file},
+        ssl_ca_file          => $args{ssl_ca_file},
+        ssl_client_ca_file   => $args{ssl_client_ca_file},
+        ssl_verify_mode      => $args{ssl_verify_mode},
         user                 => $args{user},
         group                => $args{group},
         umask                => $args{umask},
@@ -135,6 +138,9 @@ sub prepare_socket_class {
             or die "SSL suport requires IO::Socket::SSL\n";
         $args->{SSL_key_file}  = $self->{ssl_key_file};
         $args->{SSL_cert_file} = $self->{ssl_cert_file};
+        $args->{SSL_ca_file} = $self->{ssl_ca_file};
+        $args->{ssl_client_ca_file} = $self->{ssl_client_ca_file};
+        $args->{SSL_verify_mode} = $self->{ssl_verify_mode};
         return "IO::Socket::SSL";
     } elsif ($self->{ipv6}) {
         try { require IO::Socket::IP; 1 }

--- a/script/thrall.pl
+++ b/script/thrall.pl
@@ -11,7 +11,7 @@ use 5.008_001;
 use strict;
 use warnings;
 
-our $VERSION = '0.0304';
+our $VERSION = '0.0305';
 
 use Plack::Runner;
 


### PR DESCRIPTION
Allow new prarameters ssl_ca_file ssl_client_ca_file and ssl_verify_mode which are forwarded to IO::Socket::SSL.

This way you can create a SSL Servers which checks client certificates.